### PR TITLE
Lab 4. Spring Security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@ target/
 !**/src/test/**/target/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea/**
 *.iws
 *.iml
 *.ipr

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,16 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
         <!-- MapStruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>
@@ -45,7 +55,7 @@
             <version>${mapstruct.version}</version>
         </dependency>
 
-        <!-- Springdoc - OpenAPI UI (optional but useful while running locally) -->
+        <!-- Springdoc - OpenAPI UI -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
@@ -60,10 +70,15 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Test (optional) -->
+        <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/myroslav/cosmickitties/config/OpenApiConfig.java
+++ b/src/main/java/com/myroslav/cosmickitties/config/OpenApiConfig.java
@@ -1,0 +1,28 @@
+package com.myroslav.cosmickitties.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("apiKey", new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-API-KEY")
+                                .description("API Key for authentication"))
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("JWT Bearer token authentication")));
+    }
+}

--- a/src/main/java/com/myroslav/cosmickitties/security/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/myroslav/cosmickitties/security/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,81 @@
+package com.myroslav.cosmickitties.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Custom filter that authenticates requests using an API key passed in headers.
+ * <p>
+ * If the request does not contain a Bearer token, the filter will validate the
+ * API key from the {@code X-API-KEY} header. Requests without a valid API key
+ * are rejected with HTTP 401.
+ */
+@Component
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String API_KEY_HEADER = "X-API-KEY";
+
+    private final String expectedApiKey;
+
+    public ApiKeyAuthenticationFilter(@Value("${security.api-key:cosmic-kitties-secret}") String expectedApiKey) {
+        this.expectedApiKey = expectedApiKey;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // If already authenticated, or the request has a Bearer token, skip API key validation
+        Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+        if (currentAuth != null && currentAuth.isAuthenticated()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String apiKey = request.getHeader(API_KEY_HEADER);
+        if (apiKey == null || !apiKey.equals(expectedApiKey)) {
+            writeUnauthorized(response, "Invalid or missing API key");
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken("api-key-client", null,
+                        List.of(new SimpleGrantedAuthority("ROLE_API_CLIENT")));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void writeUnauthorized(HttpServletResponse response, String message) throws IOException {
+        if (response.isCommitted()) {
+            return;
+        }
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        String body = "{\"error\":\"" + message + "\"}";
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/com/myroslav/cosmickitties/security/NoAuthSecurityConfig.java
+++ b/src/main/java/com/myroslav/cosmickitties/security/NoAuthSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.myroslav.cosmickitties.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("no-auth")
+public class NoAuthSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain noAuthSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/src/main/java/com/myroslav/cosmickitties/security/SecurityConfig.java
+++ b/src/main/java/com/myroslav/cosmickitties/security/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.myroslav.cosmickitties.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+@Configuration
+@EnableWebSecurity
+@Profile("!no-auth")
+public class SecurityConfig {
+
+    private static final String JWT_SECRET = "cosmic-kitties-jwt-secret-key-256";
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                                   ApiKeyAuthenticationFilter apiKeyAuthenticationFilter) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        http.addFilterBefore(apiKeyAuthenticationFilter, BearerTokenAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        SecretKeySpec key = new SecretKeySpec(JWT_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(key).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
 springdoc:
   api-docs:
     version: OPENAPI_3_0
+
+security:
+  api-key: cosmic-kitties-secret

--- a/src/test/java/com/myroslav/cosmickitties/controller/ProductControllerNoAuthProfileTest.java
+++ b/src/test/java/com/myroslav/cosmickitties/controller/ProductControllerNoAuthProfileTest.java
@@ -1,0 +1,30 @@
+package com.myroslav.cosmickitties.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("no-auth")
+class ProductControllerNoAuthProfileTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "test-user", roles = {"USER"})
+    @DisplayName("no-auth profile allows access without real authentication")
+    void whenNoAuthProfile_thenEndpointAccessible() throws Exception {
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/myroslav/cosmickitties/controller/ProductControllerSecurityTest.java
+++ b/src/test/java/com/myroslav/cosmickitties/controller/ProductControllerSecurityTest.java
@@ -1,0 +1,42 @@
+package com.myroslav.cosmickitties.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProductControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Request without API key or token is unauthorized")
+    void whenNoAuth_thenUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Request with valid API key is authorized")
+    void whenValidApiKey_thenOk() throws Exception {
+        mockMvc.perform(get("/api/products")
+                        .header("X-API-KEY", "cosmic-kitties-secret"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Request with JWT bearer token is authorized")
+    void whenJwtToken_thenOk() throws Exception {
+        mockMvc.perform(get("/api/products").with(jwt()))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/myroslav/cosmickitties/security/ApiKeyAuthenticationFilterTest.java
+++ b/src/test/java/com/myroslav/cosmickitties/security/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,95 @@
+package com.myroslav.cosmickitties.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class ApiKeyAuthenticationFilterTest {
+
+    private final ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter("expected-key");
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("Missing API key results in 401")
+    void whenMissingApiKey_thenUnauthorized() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        assertThat(response.getContentAsString()).contains("Invalid or missing API key");
+        verify(chain, never()).doFilter(Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class));
+    }
+
+    @Test
+    @DisplayName("Invalid API key results in 401")
+    void whenInvalidApiKey_thenUnauthorized() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(ApiKeyAuthenticationFilter.API_KEY_HEADER, "wrong-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+        assertThat(response.getContentAsString()).contains("Invalid or missing API key");
+        verify(chain, never()).doFilter(Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class));
+    }
+
+    @Test
+    @DisplayName("Valid API key continues filter chain")
+    void whenValidApiKey_thenChainContinues() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(ApiKeyAuthenticationFilter.API_KEY_HEADER, "expected-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.isCommitted()).isFalse();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().isAuthenticated()).isTrue();
+        verify(chain).doFilter(Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class));
+    }
+
+    @Test
+    @DisplayName("Bearer token skips API key validation")
+    void whenBearerToken_thenSkipsApiKey() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer some-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        // Filter should pass through without checking API key
+        assertThat(response.isCommitted()).isFalse();
+        verify(chain).doFilter(Mockito.any(HttpServletRequest.class), Mockito.any(HttpServletResponse.class));
+    }
+}


### PR DESCRIPTION
Implements Spring Security configuration for protected API access

Key changes:
Configured Spring Security filter chai
Implemented custom API key authentication filter
Added no-auth Spring profile
Secured application endpoints to allow access only to authenticated requests (JWT or API key)
Added integration and unit tests for security configuration